### PR TITLE
Rework BUILDTAG to follow Contrail build naming convention.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,6 @@
-SRC_VER := $(shell cat ./../controller/src/base/version.info)
-BUILDTIME := $(shell date -u +%m%d%Y)
-
-ifdef SRC_VER
-BUILDTAG = $(SRC_VER)-$(BUILDTIME)
-else
-BUILDTAG = $(BUILDTIME)
-endif
-
+SRC_VER ?= $(shell cat ./../controller/src/base/version.info)
+BUILDNUM ?= $(shell date -u +%m%d%Y)
+export BUILDTAG ?= $(SRC_VER)-$(BUILDNUM)
 
 all:
 	$(eval BUILDDIR=./../build/vcenter-plugin)
@@ -15,7 +9,7 @@ all:
 	(cd ${BUILDDIR}; mvn install)
 	#(cd ${BUILDDIR}; fakeroot debian/rules clean)
 	#(cd ${BUILDDIR}; fakeroot debian/rules binary)
-	(cd ${BUILDDIR}; debuild -i -us -uc -b)
+	(cd ${BUILDDIR}; debuild --preserve-envvar=BUILDTAG -i -us -uc -b)
 	@echo "Wrote: ${BUILDDIR}/../contrail-vcenter-plugin_all.deb"
 
 clean:

--- a/Makefile.install-package
+++ b/Makefile.install-package
@@ -1,4 +1,7 @@
 
+SRC_VER := $(shell cat ./controller/src/base/version.info)
+BUILDNUM ?= $(shell date -u +%m%d%Y)
+export BUILDTAG ?= $(SRC_VER)-$(BUILDNUM)
 
 vijava-deb:
 	(cd vijava && make all)
@@ -16,7 +19,7 @@ install-package-deb:
 	$(eval BUILDDIR=./build/packages)
 	mkdir -p ${BUILDDIR}
 	cp -ar vcenter-plugin/packages/* ${BUILDDIR}
-	(cd ${BUILDDIR}; debuild -i -us -uc -b)
+	(cd ${BUILDDIR}; debuild --preserve-envvar=BUILDTAG -i -us -uc -b)
 	@echo "Wrote: build/contrail-vcenter-plugin_all.deb"
 
 clean-install-package:

--- a/debian/rules
+++ b/debian/rules
@@ -4,14 +4,9 @@
 export INSTALL_ROOT=$(shell pwd)
 JAVA_HOME=/usr/lib/jvm/default-java
 
-SRC_VER := $(shell cat ./../../controller/src/base/version.info)
-BUILDTIME := $(shell date -u +%m%d%Y)
-
-ifdef SRC_VER
-BUILDTAG = $(SRC_VER)-$(BUILDTIME)
-else
-BUILDTAG = $(BUILDTIME)
-endif
+SRC_VER ?= $(shell cat ./../controller/src/base/version.info)
+BUILDNUM ?= $(shell date -u +%m%d%Y)
+export BUILDTAG ?= $(SRC_VER)-$(BUILDNUM)
 
 %:
 	dh $@ --with javahelper

--- a/packages/debian/rules
+++ b/packages/debian/rules
@@ -3,14 +3,9 @@
 export INSTALL_ROOT=$(shell pwd)
 JAVA_HOME=/usr/lib/jvm/default-java
 
-SRC_VER := $(shell cat ./../../controller/src/base/version.info)
-BUILDDATE := $(shell date -u +%m%d%Y)
-
-ifdef SRC_VER
-BUILDTAG = $(SRC_VER)-$(BUILDDATE)
-else
-BUILDTAG = $(BUILDDATE)
-endif
+SRC_VER ?= $(shell cat ./../../controller/src/base/version.info)
+BUILDNUM ?= $(shell date -u +%m%d%Y)
+export BUILDTAG ?= $(SRC_VER)-$(BUILDNUM)
 
 %:
 	dh $@ --with javahelper


### PR DESCRIPTION
This will make EC build version string work.